### PR TITLE
处理高版本pydantic不兼容问题

### DIFF
--- a/nonebot_plugin_who_at_me/config.py
+++ b/nonebot_plugin_who_at_me/config.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from pydantic import BaseModel, Extra
+from pydantic.v1 import BaseModel, Extra
 
 
 class Config(BaseModel, extra=Extra.ignore):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ nonebot2 = "^2.0.0-beta.4"
 nonebot-adapter-onebot = "^2.1.1"
 peewee = ">=3.14.4"
 black = "^22.8.0"
+pydantic = "2.10.6"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
目前大部分插件使用2.0版本以上的pydantic，为保证兼容，建议使用2.0版本内置的v1版本